### PR TITLE
feat(server): `wherever install` background-service command

### DIFF
--- a/.changeset/wherever-install-service.md
+++ b/.changeset/wherever-install-service.md
@@ -1,0 +1,11 @@
+---
+"wherever-dev": minor
+---
+
+Add `wherever install` / `uninstall` / `service-status` subcommands to run the server as a background service.
+
+On Linux it writes a systemd unit (a per-user unit under `~/.config/systemd/user/` by default, or a system-wide unit with `--system`) and enables/starts it. On macOS it writes and loads a per-user launchd LaunchAgent under `~/Library/LaunchAgents/`. Server flags like `--port`, `--host`, and `--token` are baked into the service invocation.
+
+On install (unless `--no-pi-config`) the `npm:@wherever-dev/pi` extension is added to the `packages` array in `~/.pi/agent/settings.json` if it is not already configured, so a running pi CLI bridges into the same server automatically. The existing settings file is backed up to `settings.json.bak` before it is modified. A `--dry-run` flag prints the unit/plist and the actions without writing anything.
+
+Running `wherever` with no subcommand still starts the server exactly as before. Windows is not supported yet; the command prints the manual steps instead.

--- a/.changeset/wherever-install-service.md
+++ b/.changeset/wherever-install-service.md
@@ -8,4 +8,4 @@ On Linux it writes a systemd unit (a per-user unit under `~/.config/systemd/user
 
 On install (unless `--no-pi-config`) the `npm:@wherever-dev/pi` extension is added to the `packages` array in `~/.pi/agent/settings.json` if it is not already configured, so a running pi CLI bridges into the same server automatically. The existing settings file is backed up to `settings.json.bak` before it is modified. A `--dry-run` flag prints the unit/plist and the actions without writing anything.
 
-Running `wherever` with no subcommand still starts the server exactly as before. Windows is not supported yet; the command prints the manual steps instead.
+The server is now started with an explicit verb: `wherever start [server flags]`. A bare `wherever` prints the command help instead of starting the server (breaking change; acceptable pre-1.0). All existing server flags work unchanged after `start`. Windows is not supported yet; the command prints the manual steps instead.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -112,7 +112,7 @@ Wherever is a TypeScript extension for the [pi coding agent](https://pi.dev) tha
 
 ### Service Install (`wherever install`)
 
-The standalone server (`server/`, bin `wherever`) can install itself as a background service. `server/src/index.ts` dispatches on the first argv: `install` / `uninstall` / `service-status` (aliased `status`) route to `server/src/commands/install.ts`; anything else (including no subcommand) runs the server unchanged.
+The standalone server (`server/`, bin `wherever`) uses explicit verbs. `server/src/index.ts` dispatches on the first argv: `start` runs the server (server flags follow it; the `start` token is stripped from `process.argv` before `main()` so the existing flag parser is unchanged), `install` / `uninstall` / `service-status` (aliased `status`) route to `server/src/commands/install.ts`, and a bare `wherever` (or `help`) prints usage. An unknown verb prints usage and exits 1. The generated service unit invokes `wherever start ...`.
 
 - **Linux**: systemd unit. Per-user (`~/.config/systemd/user/wherever.service`) by default, or system-wide (`/etc/systemd/system/wherever.service`) with `--system` (needs root). Enabled + started via `systemctl [--user] enable --now wherever`.
 - **macOS**: per-user launchd LaunchAgent at `~/Library/LaunchAgents/dev.wherever.server.plist`, loaded via `launchctl`. `--system` is not supported.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -110,6 +110,17 @@ Wherever is a TypeScript extension for the [pi coding agent](https://pi.dev) tha
 - `POST /session/compact` - Trigger compaction
 - `GET /health` - Health check (no auth)
 
+### Service Install (`wherever install`)
+
+The standalone server (`server/`, bin `wherever`) can install itself as a background service. `server/src/index.ts` dispatches on the first argv: `install` / `uninstall` / `service-status` (aliased `status`) route to `server/src/commands/install.ts`; anything else (including no subcommand) runs the server unchanged.
+
+- **Linux**: systemd unit. Per-user (`~/.config/systemd/user/wherever.service`) by default, or system-wide (`/etc/systemd/system/wherever.service`) with `--system` (needs root). Enabled + started via `systemctl [--user] enable --now wherever`.
+- **macOS**: per-user launchd LaunchAgent at `~/Library/LaunchAgents/dev.wherever.server.plist`, loaded via `launchctl`. `--system` is not supported.
+- **Windows**: not supported yet; the command prints the manual steps.
+- Server flags `--port` / `--host` / `--token` are baked into the service's `ExecStart` / `ProgramArguments`.
+- **Pi config injection**: unless `--no-pi-config`, install adds `"npm:@wherever-dev/pi"` to the `packages` array in `~/.pi/agent/settings.json` (creating the file if missing) when not already present, backing up to `settings.json.bak` first.
+- `--dry-run` prints the generated unit/plist and intended actions without writing anything.
+
 ### Authentication
 
 - Optional token via `--remote-token` flag

--- a/README.md
+++ b/README.md
@@ -135,6 +135,38 @@ Pi will automatically detect and load the `@wherever-dev/pi` extension, establis
 
 Note though that when pi cli run, it takes control of the brain operation and quiting (via ctrl+c, /quit, etc...) will interupt the conversation even on every devices
 
+#### 5. Run as a Background Service (Optional)
+
+Instead of keeping a terminal open, you can install Wherever as a background service that starts automatically and restarts on failure:
+
+```bash
+wherever install
+```
+
+This installs and starts a per-user service (a **systemd** user unit on Linux, or a **launchd** LaunchAgent on macOS). It also adds the `@wherever-dev/pi` extension to `~/.pi/agent/settings.json` for you (unless it is already configured), so a running `pi` CLI bridges into the server automatically.
+
+Server flags are baked into the service, so you can pass them through at install time:
+
+```bash
+wherever install --host 0.0.0.0 --token your-secure-token --port 31415
+```
+
+Other subcommands:
+
+```bash
+wherever service-status   # show whether the service is running
+wherever uninstall        # stop and remove the service
+```
+
+Install options:
+
+- `--system` — Install a system-wide service instead of a per-user one (Linux only, requires root).
+- `--no-pi-config` — Do not modify `~/.pi/agent/settings.json`.
+- `--port` / `--host` / `--token` — Server flags to bake into the service invocation.
+- `--dry-run` — Print the generated unit/plist and the intended actions without writing anything.
+
+> On Linux user services, run `loginctl enable-linger $USER` if you want the service to keep running after you log out. Windows is not supported yet; run `wherever` manually or use a tool like NSSM.
+
 ---
 
 ### Method B: Local Development Setup (From Source) 🛠️

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ pi install npm:@wherever-dev/pi
 Start the standalone multi-session server:
 
 ```bash
-wherever
+wherever start
 ```
 
 The server will boot up and automatically generate self-signed SSL certificates for a secure `https`/`wss` local environment. Open `https://localhost:31415` in your browser. (The first time, proceed past your browser's SSL warning).
@@ -165,7 +165,9 @@ Install options:
 - `--port` / `--host` / `--token` — Server flags to bake into the service invocation.
 - `--dry-run` — Print the generated unit/plist and the intended actions without writing anything.
 
-> On Linux user services, run `loginctl enable-linger $USER` if you want the service to keep running after you log out. Windows is not supported yet; run `wherever` manually or use a tool like NSSM.
+> On Linux user services, run `loginctl enable-linger $USER` if you want the service to keep running after you log out. Windows is not supported yet; run `wherever start` manually or use a tool like NSSM.
+
+> Note: the server is started with the explicit `wherever start` verb. A bare `wherever` prints the command help. All server flags below apply to `wherever start`.
 
 ---
 
@@ -358,7 +360,7 @@ Using a secure private mesh VPN like [Tailscale](https://tailscale.com) or [Head
 1. Install Tailscale/Headscale on both your machine and your remote client device (e.g., your phone).
 2. Start the Wherever server binding to all interfaces (or your specific Tailscale IP):
    ```bash
-   wherever --host 0.0.0.0 --token your-secure-token
+   wherever start --host 0.0.0.0 --token your-secure-token
    ```
    _Warning: Always use a strong `--token` when binding to any interface other than localhost!_
 3. Access your Svelte dashboard securely from your remote device's browser at `https://<your-tailscale-ip>:31415` with your token.
@@ -380,7 +382,7 @@ Replace `your-machine.your-tailnet.ts.net` below with your device's MagicDNS nam
 # Issue a cert for your MagicDNS name (writes <name>.crt and <name>.key)
 tailscale cert your-machine.your-tailnet.ts.net
 
-wherever --host 0.0.0.0 --token your-secure-token \
+wherever start --host 0.0.0.0 --token your-secure-token \
   --ssl-cert your-machine.your-tailnet.ts.net.crt \
   --ssl-key  your-machine.your-tailnet.ts.net.key
 ```
@@ -395,7 +397,7 @@ tailscale cert \
   --key-file  ~/.wherever/certs/localhost.key \
   your-machine.your-tailnet.ts.net
 
-wherever --host 0.0.0.0 --token your-secure-token
+wherever start --host 0.0.0.0 --token your-secure-token
 ```
 
 _(The filenames stay `localhost.*` but contain a cert for your MagicDNS name; the server only cares about the path, not the name.)_
@@ -412,7 +414,7 @@ To allow access from devices on your local home network (Wi-Fi):
 
 1. Start the server binding to `0.0.0.0`:
    ```bash
-   wherever --host 0.0.0.0 --token your-secure-token
+   wherever start --host 0.0.0.0 --token your-secure-token
    ```
 2. Find your Pi's local network IP (e.g., `192.168.1.50`) and open `https://192.168.1.50:31415` in your client's browser.
 3. If running the CLI `pi` command from another computer on the same local network, point it to the Pi:

--- a/server/src/commands/install.ts
+++ b/server/src/commands/install.ts
@@ -46,7 +46,9 @@ function resolveServiceContext(opts: InstallOptions): ServiceContext {
   const __filename = fileURLToPath(import.meta.url);
   // dist/commands/install.js -> dist/index.js
   const serverEntry = path.resolve(path.dirname(__filename), '..', 'index.js');
-  const serverArgs: string[] = [];
+  // The server is started via the explicit `start` verb; bare invocation prints
+  // help, so the service must pass `start` before any flags.
+  const serverArgs: string[] = ['start'];
   if (opts.port !== undefined) serverArgs.push('--port', String(opts.port));
   if (opts.host !== undefined) serverArgs.push('--host', opts.host);
   if (opts.token !== undefined) serverArgs.push('--token', opts.token);
@@ -443,10 +445,11 @@ export function printInstallHelp(): void {
   console.log(`wherever - remote control server for the pi coding agent
 
 Usage:
-  wherever [server options]        Run the server (default; see --help below)
+  wherever start [server options]  Run the server
   wherever install [options]       Install & start a background service
   wherever uninstall [options]     Stop & remove the background service
   wherever service-status          Show the service status
+  wherever help                    Show this help
 
 Install options:
   --system            Install a system-wide service (Linux only, needs root).

--- a/server/src/commands/install.ts
+++ b/server/src/commands/install.ts
@@ -1,0 +1,463 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * `wherever install` and friends.
+ *
+ * Installs (or removes) a background service that runs the wherever server, and
+ * optionally wires the `@wherever-dev/pi` extension into the user's pi config so
+ * a running pi CLI bridges into the same server automatically.
+ *
+ * Supported platforms:
+ *   - Linux  : systemd user unit (default) or system unit (`--system`, needs root)
+ *   - macOS  : launchd LaunchAgent (per-user)
+ * Windows is not supported yet; the command prints the manual steps instead.
+ */
+
+const SERVICE_NAME = 'wherever';
+// Reverse-DNS label used by launchd (the plist Label + filename stem).
+const LAUNCHD_LABEL = 'dev.wherever.server';
+
+export interface InstallOptions {
+  system: boolean;
+  configurePi: boolean;
+  // Server flags to bake into the service invocation (pass-through).
+  port?: number;
+  host?: string;
+  token?: string;
+  // When true, only print what would happen; write nothing.
+  dryRun: boolean;
+}
+
+interface ServiceContext {
+  /** Absolute path to the node binary that should run the server. */
+  nodePath: string;
+  /** Absolute path to the wherever server entrypoint (dist/index.js). */
+  serverEntry: string;
+  /** Extra CLI args passed to the server (e.g. --port 31415). */
+  serverArgs: string[];
+  homeDir: string;
+}
+
+function resolveServiceContext(opts: InstallOptions): ServiceContext {
+  const __filename = fileURLToPath(import.meta.url);
+  // dist/commands/install.js -> dist/index.js
+  const serverEntry = path.resolve(path.dirname(__filename), '..', 'index.js');
+  const serverArgs: string[] = [];
+  if (opts.port !== undefined) serverArgs.push('--port', String(opts.port));
+  if (opts.host !== undefined) serverArgs.push('--host', opts.host);
+  if (opts.token !== undefined) serverArgs.push('--token', opts.token);
+  return {
+    nodePath: process.execPath,
+    serverEntry,
+    serverArgs,
+    homeDir: os.homedir(),
+  };
+}
+
+/** Quote a single argument for an ExecStart / plist string array member. */
+function shellQuote(arg: string): string {
+  if (/^[A-Za-z0-9_./:=-]+$/.test(arg)) return arg;
+  return `"${arg.replace(/(["\\$`])/g, '\\$1')}"`;
+}
+
+// ---------------------------------------------------------------------------
+// systemd (Linux)
+// ---------------------------------------------------------------------------
+
+function systemdUnitPath(system: boolean, homeDir: string): string {
+  if (system) return path.join('/etc/systemd/system', `${SERVICE_NAME}.service`);
+  return path.join(homeDir, '.config', 'systemd', 'user', `${SERVICE_NAME}.service`);
+}
+
+function renderSystemdUnit(ctx: ServiceContext, system: boolean): string {
+  const execStart = [ctx.nodePath, ctx.serverEntry, ...ctx.serverArgs]
+    .map(shellQuote)
+    .join(' ');
+  const lines = [
+    '[Unit]',
+    'Description=Wherever server (remote control for the pi coding agent)',
+    'After=network-online.target',
+    'Wants=network-online.target',
+    '',
+    '[Service]',
+    'Type=simple',
+    `ExecStart=${execStart}`,
+    'Restart=on-failure',
+    'RestartSec=5',
+    '',
+    '[Install]',
+    system ? 'WantedBy=multi-user.target' : 'WantedBy=default.target',
+    '',
+  ];
+  return lines.join('\n');
+}
+
+function runSystemctl(system: boolean, args: string[]): void {
+  const base = system ? ['systemctl'] : ['systemctl', '--user'];
+  const cmd = base[0];
+  const cmdArgs = [...base.slice(1), ...args];
+  execFileSync(cmd, cmdArgs, { stdio: 'inherit' });
+}
+
+function installSystemd(ctx: ServiceContext, opts: InstallOptions): void {
+  const unitPath = systemdUnitPath(opts.system, ctx.homeDir);
+  const unit = renderSystemdUnit(ctx, opts.system);
+
+  if (opts.dryRun) {
+    console.log(`[dry-run] would write systemd unit to: ${unitPath}`);
+    console.log('---');
+    console.log(unit);
+    console.log('---');
+    console.log(`[dry-run] would run: systemctl ${opts.system ? '' : '--user '}daemon-reload`);
+    console.log(`[dry-run] would run: systemctl ${opts.system ? '' : '--user '}enable --now ${SERVICE_NAME}`);
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(unitPath), { recursive: true });
+  fs.writeFileSync(unitPath, unit, 'utf-8');
+  console.log(`Wrote systemd unit: ${unitPath}`);
+
+  runSystemctl(opts.system, ['daemon-reload']);
+  runSystemctl(opts.system, ['enable', '--now', SERVICE_NAME]);
+  console.log(`Service '${SERVICE_NAME}' enabled and started.`);
+  if (!opts.system) {
+    console.log(
+      'Tip: run `loginctl enable-linger $USER` so the service keeps running after you log out.',
+    );
+  }
+}
+
+function uninstallSystemd(opts: InstallOptions): void {
+  const unitPath = systemdUnitPath(opts.system, os.homedir());
+  if (opts.dryRun) {
+    console.log(`[dry-run] would run: systemctl ${opts.system ? '' : '--user '}disable --now ${SERVICE_NAME}`);
+    console.log(`[dry-run] would remove: ${unitPath}`);
+    return;
+  }
+  try {
+    runSystemctl(opts.system, ['disable', '--now', SERVICE_NAME]);
+  } catch {
+    // Service may not be running/enabled; keep going and remove the unit file.
+  }
+  if (fs.existsSync(unitPath)) {
+    fs.rmSync(unitPath);
+    console.log(`Removed systemd unit: ${unitPath}`);
+  }
+  try {
+    runSystemctl(opts.system, ['daemon-reload']);
+  } catch {
+    /* best effort */
+  }
+  console.log(`Service '${SERVICE_NAME}' removed.`);
+}
+
+function statusSystemd(opts: InstallOptions): void {
+  try {
+    runSystemctl(opts.system, ['status', SERVICE_NAME, '--no-pager']);
+  } catch {
+    // systemctl status exits non-zero for inactive/failed units; that's fine,
+    // its output was already streamed to the console.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// launchd (macOS)
+// ---------------------------------------------------------------------------
+
+function launchdPlistPath(homeDir: string): string {
+  return path.join(homeDir, 'Library', 'LaunchAgents', `${LAUNCHD_LABEL}.plist`);
+}
+
+function renderLaunchdPlist(ctx: ServiceContext): string {
+  const programArgs = [ctx.nodePath, ctx.serverEntry, ...ctx.serverArgs];
+  const argsXml = programArgs
+    .map((a) => `    <string>${escapeXml(a)}</string>`)
+    .join('\n');
+  const logPath = path.join(ctx.homeDir, 'Library', 'Logs', `${LAUNCHD_LABEL}.log`);
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+    '<plist version="1.0">',
+    '<dict>',
+    '  <key>Label</key>',
+    `  <string>${LAUNCHD_LABEL}</string>`,
+    '  <key>ProgramArguments</key>',
+    '  <array>',
+    argsXml,
+    '  </array>',
+    '  <key>RunAtLoad</key>',
+    '  <true/>',
+    '  <key>KeepAlive</key>',
+    '  <true/>',
+    '  <key>StandardOutPath</key>',
+    `  <string>${escapeXml(logPath)}</string>`,
+    '  <key>StandardErrorPath</key>',
+    `  <string>${escapeXml(logPath)}</string>`,
+    '</dict>',
+    '</plist>',
+    '',
+  ].join('\n');
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function installLaunchd(ctx: ServiceContext, opts: InstallOptions): void {
+  if (opts.system) {
+    throw new Error(
+      'System-level (LaunchDaemon) install is not supported on macOS yet; omit --system to install a per-user LaunchAgent.',
+    );
+  }
+  const plistPath = launchdPlistPath(ctx.homeDir);
+  const plist = renderLaunchdPlist(ctx);
+
+  if (opts.dryRun) {
+    console.log(`[dry-run] would write launchd plist to: ${plistPath}`);
+    console.log('---');
+    console.log(plist);
+    console.log('---');
+    console.log(`[dry-run] would run: launchctl unload ${plistPath} (if loaded)`);
+    console.log(`[dry-run] would run: launchctl load ${plistPath}`);
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(plistPath), { recursive: true });
+  fs.mkdirSync(path.join(ctx.homeDir, 'Library', 'Logs'), { recursive: true });
+  fs.writeFileSync(plistPath, plist, 'utf-8');
+  console.log(`Wrote launchd plist: ${plistPath}`);
+
+  // Reload: unload first (ignore errors) so a re-install picks up changes.
+  try {
+    execFileSync('launchctl', ['unload', plistPath], { stdio: 'ignore' });
+  } catch {
+    /* not previously loaded */
+  }
+  execFileSync('launchctl', ['load', plistPath], { stdio: 'inherit' });
+  console.log(`Service '${LAUNCHD_LABEL}' loaded and started.`);
+}
+
+function uninstallLaunchd(opts: InstallOptions): void {
+  const plistPath = launchdPlistPath(os.homedir());
+  if (opts.dryRun) {
+    console.log(`[dry-run] would run: launchctl unload ${plistPath}`);
+    console.log(`[dry-run] would remove: ${plistPath}`);
+    return;
+  }
+  try {
+    execFileSync('launchctl', ['unload', plistPath], { stdio: 'ignore' });
+  } catch {
+    /* not loaded */
+  }
+  if (fs.existsSync(plistPath)) {
+    fs.rmSync(plistPath);
+    console.log(`Removed launchd plist: ${plistPath}`);
+  }
+  console.log(`Service '${LAUNCHD_LABEL}' removed.`);
+}
+
+function statusLaunchd(): void {
+  try {
+    execFileSync('launchctl', ['list', LAUNCHD_LABEL], { stdio: 'inherit' });
+  } catch {
+    console.log(`Service '${LAUNCHD_LABEL}' is not loaded.`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// pi extension config injection
+// ---------------------------------------------------------------------------
+
+const PI_PACKAGE = 'npm:@wherever-dev/pi';
+
+function piSettingsPath(homeDir: string): string {
+  return path.join(homeDir, '.pi', 'agent', 'settings.json');
+}
+
+/**
+ * Substrings that identify this extension in a settings entry. `@wherever-dev/pi`
+ * is the npm package name; `wherever` catches a local dev path/symlink. Matching
+ * either avoids double-registering when it is already wired in.
+ */
+const PI_EXTENSION_MARKERS = ['@wherever-dev/pi', 'wherever'];
+
+function entryReferencesExtension(value: string): boolean {
+  return PI_EXTENSION_MARKERS.some((m) => value.includes(m));
+}
+
+/** True if the extension is already referenced anywhere in the settings. */
+function piExtensionConfigured(settings: any): boolean {
+  const inPackages = Array.isArray(settings.packages) &&
+    settings.packages.some((p: any) => {
+      if (typeof p === 'string') return entryReferencesExtension(p);
+      if (p && typeof p === 'object' && typeof p.source === 'string') {
+        return entryReferencesExtension(p.source);
+      }
+      return false;
+    });
+  const inExtensions = Array.isArray(settings.extensions) &&
+    settings.extensions.some((e: any) => typeof e === 'string' && entryReferencesExtension(e));
+  return inPackages || inExtensions;
+}
+
+export function configurePiExtension(homeDir: string, dryRun: boolean): void {
+  const settingsPath = piSettingsPath(homeDir);
+
+  if (!fs.existsSync(settingsPath)) {
+    if (dryRun) {
+      console.log(`[dry-run] pi settings not found at ${settingsPath}; would create it with the wherever extension.`);
+      return;
+    }
+    const fresh = { packages: [PI_PACKAGE] };
+    fs.mkdirSync(path.dirname(settingsPath), { recursive: true });
+    fs.writeFileSync(settingsPath, JSON.stringify(fresh, null, 2) + '\n', 'utf-8');
+    console.log(`Created pi settings and added the wherever extension: ${settingsPath}`);
+    return;
+  }
+
+  let settings: any;
+  try {
+    settings = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+  } catch (err) {
+    console.warn(
+      `Could not parse ${settingsPath} (${(err as Error).message}); skipping pi extension config. ` +
+      `Add "${PI_PACKAGE}" to its "packages" array manually.`,
+    );
+    return;
+  }
+
+  if (piExtensionConfigured(settings)) {
+    console.log('pi extension already configured; leaving settings.json untouched.');
+    return;
+  }
+
+  if (dryRun) {
+    console.log(`[dry-run] would add "${PI_PACKAGE}" to "packages" in ${settingsPath}`);
+    return;
+  }
+
+  if (!Array.isArray(settings.packages)) settings.packages = [];
+  settings.packages.push(PI_PACKAGE);
+
+  // Back up before mutating, so a bad edit is always recoverable.
+  fs.copyFileSync(settingsPath, `${settingsPath}.bak`);
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+  console.log(`Added "${PI_PACKAGE}" to pi settings (backup at ${settingsPath}.bak).`);
+}
+
+// ---------------------------------------------------------------------------
+// dispatch
+// ---------------------------------------------------------------------------
+
+export function runInstall(opts: InstallOptions): void {
+  const ctx = resolveServiceContext(opts);
+  switch (process.platform) {
+    case 'linux':
+      installSystemd(ctx, opts);
+      break;
+    case 'darwin':
+      installLaunchd(ctx, opts);
+      break;
+    default:
+      printUnsupported('install');
+      return;
+  }
+  if (opts.configurePi) {
+    configurePiExtension(ctx.homeDir, opts.dryRun);
+  }
+}
+
+export function runUninstall(opts: InstallOptions): void {
+  switch (process.platform) {
+    case 'linux':
+      uninstallSystemd(opts);
+      break;
+    case 'darwin':
+      uninstallLaunchd(opts);
+      break;
+    default:
+      printUnsupported('uninstall');
+  }
+}
+
+export function runServiceStatus(opts: InstallOptions): void {
+  switch (process.platform) {
+    case 'linux':
+      statusSystemd(opts);
+      break;
+    case 'darwin':
+      statusLaunchd();
+      break;
+    default:
+      printUnsupported('status');
+  }
+}
+
+function printUnsupported(verb: string): void {
+  console.error(
+    `\`wherever ${verb}\` is not supported on ${process.platform} yet (Linux and macOS only).\n` +
+    'You can still run the server directly with `wherever` (no subcommand),\n' +
+    `and add "${PI_PACKAGE}" to the "packages" array in ~/.pi/agent/settings.json manually.`,
+  );
+}
+
+export function parseInstallOptions(args: string[]): InstallOptions {
+  const opts: InstallOptions = {
+    system: false,
+    configurePi: true,
+    dryRun: false,
+  };
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--system':
+        opts.system = true;
+        break;
+      case '--no-pi-config':
+        opts.configurePi = false;
+        break;
+      case '--dry-run':
+        opts.dryRun = true;
+        break;
+      case '--port':
+        opts.port = parseInt(args[++i] || '', 10);
+        break;
+      case '--host':
+        opts.host = args[++i];
+        break;
+      case '--token':
+        opts.token = args[++i];
+        break;
+    }
+  }
+  return opts;
+}
+
+export function printInstallHelp(): void {
+  console.log(`wherever - remote control server for the pi coding agent
+
+Usage:
+  wherever [server options]        Run the server (default; see --help below)
+  wherever install [options]       Install & start a background service
+  wherever uninstall [options]     Stop & remove the background service
+  wherever service-status          Show the service status
+
+Install options:
+  --system            Install a system-wide service (Linux only, needs root).
+                      Default is a per-user service (no sudo).
+  --no-pi-config      Do not touch ~/.pi/agent/settings.json.
+  --port <n>          Port for the service to listen on.
+  --host <addr>       Host/interface to bind.
+  --token <token>     Auth token to bake into the service.
+  --dry-run           Print what would happen without writing anything.
+
+Platforms: Linux (systemd) and macOS (launchd). On install, the
+'${PI_PACKAGE}' extension is added to your pi config unless --no-pi-config.
+`);
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -11,6 +11,13 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import os from 'node:os';
 import { execSync } from 'node:child_process';
+import {
+  runInstall,
+  runUninstall,
+  runServiceStatus,
+  parseInstallOptions,
+  printInstallHelp,
+} from './commands/install.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -1693,7 +1700,38 @@ function extractText(msg: any): string {
   return '';
 }
 
-main().catch((err) => {
-  console.error('Fatal server startup error:', err);
-  process.exit(1);
-});
+/**
+ * Subcommand dispatch. `wherever <verb>` routes service management to the
+ * install module; anything else (including no subcommand) runs the server, so
+ * the historical `wherever [server flags]` behavior is unchanged.
+ */
+function dispatch(): void {
+  const argv = process.argv.slice(2);
+  const verb = argv[0];
+  const rest = argv.slice(1);
+
+  switch (verb) {
+    case 'install':
+      runInstall(parseInstallOptions(rest));
+      return;
+    case 'uninstall':
+      runUninstall(parseInstallOptions(rest));
+      return;
+    case 'service-status':
+    case 'status':
+      runServiceStatus(parseInstallOptions(rest));
+      return;
+    case 'help':
+    case '--help':
+    case '-h':
+      printInstallHelp();
+      return;
+    default:
+      main().catch((err) => {
+        console.error('Fatal server startup error:', err);
+        process.exit(1);
+      });
+  }
+}
+
+dispatch();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1701,9 +1701,12 @@ function extractText(msg: any): string {
 }
 
 /**
- * Subcommand dispatch. `wherever <verb>` routes service management to the
- * install module; anything else (including no subcommand) runs the server, so
- * the historical `wherever [server flags]` behavior is unchanged.
+ * Subcommand dispatch. Every action is an explicit verb:
+ *   - `wherever start [server flags]` runs the server
+ *   - `wherever install|uninstall|service-status` manage the background service
+ *   - bare `wherever` (or `help`) prints usage
+ * Server flags after `start` are consumed by parseArgs() (which reads
+ * process.argv), so `start` is stripped from argv before main() runs.
  */
 function dispatch(): void {
   const argv = process.argv.slice(2);
@@ -1711,6 +1714,15 @@ function dispatch(): void {
   const rest = argv.slice(1);
 
   switch (verb) {
+    case 'start':
+      // Drop the `start` verb so the existing flag parser sees only server
+      // flags (it reads process.argv directly).
+      process.argv.splice(2, 1);
+      main().catch((err) => {
+        console.error('Fatal server startup error:', err);
+        process.exit(1);
+      });
+      return;
     case 'install':
       runInstall(parseInstallOptions(rest));
       return;
@@ -1721,16 +1733,16 @@ function dispatch(): void {
     case 'status':
       runServiceStatus(parseInstallOptions(rest));
       return;
+    case undefined:
     case 'help':
     case '--help':
     case '-h':
       printInstallHelp();
       return;
     default:
-      main().catch((err) => {
-        console.error('Fatal server startup error:', err);
-        process.exit(1);
-      });
+      console.error(`Unknown command: ${verb}\n`);
+      printInstallHelp();
+      process.exit(1);
   }
 }
 

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -57,14 +57,13 @@
 		{
 			number: '01',
 			title: 'Install the Server',
-			description:
-				'Install the wherever-dev server package globally or locally in your project.',
+			description: 'Install the wherever-dev server package globally.',
 			code: 'npm install -g wherever-dev',
 		},
 		{
 			number: '02',
 			title: 'Start the Server',
-			description: 'Launch the server with your preferred token and port.',
+			description: 'Run one command to launch the server.',
 			code: 'wherever start',
 		},
 		{

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -69,6 +69,13 @@
 		},
 		{
 			number: '03',
+			title: 'Run it as a Service',
+			description:
+				'Optional: install a background service (systemd on Linux, launchd on macOS) that starts on boot and wires the pi extension in automatically.',
+			code: 'wherever install',
+		},
+		{
+			number: '04',
 			title: 'Open the Dashboard',
 			description:
 				'Open the dashboard in your browser and start creating and maintaining your apps.',

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -65,7 +65,7 @@
 			number: '02',
 			title: 'Start the Server',
 			description: 'Launch the server with your preferred token and port.',
-			code: 'wherever',
+			code: 'wherever start',
 		},
 		{
 			number: '03',


### PR DESCRIPTION
## What

Adds a `wherever install` command (plus `uninstall` and `service-status`) that runs the standalone server as a background service, and optionally wires the pi extension into `~/.pi/agent/settings.json`.

Also makes the CLI use explicit verbs: **`wherever start`** runs the server; a bare `wherever` prints help (breaking change, acceptable pre-1.0).

## CLI shape

- `wherever start [server flags]` — run the server (all existing flags: `--port`, `--host`, `--token`, `--no-ssl`, `--ssl-cert`, ...).
- `wherever install [options]` — install & start the background service.
- `wherever uninstall` — stop & remove the service.
- `wherever service-status` — show service status.
- bare `wherever` / `wherever help` — print usage. Unknown verb prints usage and exits 1.

## Service install

- **Linux (systemd):** per-user unit at `~/.config/systemd/user/wherever.service` by default, or a system unit at `/etc/systemd/system/wherever.service` with `--system` (needs root). Enabled + started via `systemctl [--user] enable --now`.
- **macOS (launchd):** per-user LaunchAgent at `~/Library/LaunchAgents/dev.wherever.server.plist`, loaded via `launchctl`.
- **Windows:** not supported yet; prints the manual steps.
- The generated unit/plist invokes `wherever start ...`; server flags `--port` / `--host` / `--token` are baked in.
- **Pi config injection:** unless `--no-pi-config`, adds `"npm:@wherever-dev/pi"` to the `packages` array in `~/.pi/agent/settings.json` (creating the file if missing) when not already present, backing up to `settings.json.bak` first.
- `--dry-run` prints the generated unit/plist and intended actions without writing anything.

## Implementation

- New module `server/src/commands/install.ts` (platform logic + pi-config injection).
- `server/src/index.ts` gains a verb `dispatch()` at the entrypoint. `start` is stripped from argv before `main()` so the existing flag parser is unchanged.

## Docs

- README (service section + all server-start examples now use `wherever start`).
- `CONTEXT.md` service/dispatch section.
- Marketing site install step (`site/`).

## Release

Changeset `wherever-dev: minor` (notes the breaking bare-invocation change).

## Verification

`pnpm format:check` and `pnpm build:all` / `site:build` pass. Verified: bare `wherever` prints help, `wherever start --port ... --no-ssl` boots and passes flags through, unknown verb exits 1, and `install --dry-run` emits `ExecStart=... index.js start --port ...`.